### PR TITLE
Fix the raising of an exception in NFTItemSaleParser

### DIFF
--- a/parser/parsers_collection.py
+++ b/parser/parsers_collection.py
@@ -888,7 +888,6 @@ class NFTItemSaleParser(ContractsExecutorParser):
             from parser.nft_contracts import SALE_CONTRACTS
         except Exception as e:
             logger.error("Unable to init sale contracts", e)
-            raise e
             SALE_CONTRACTS = {}
         """
         Supported sale contract should be listed in file nft_contracts, format as follows:


### PR DESCRIPTION
Fix the raising of an exception in NFTItemSaleParser when a file "parsers_collection.py" is missing